### PR TITLE
Add option to inject an instance of Aws::S3::Client to WT::S3Signer.for_s3_bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.3.0
+* Add option `client:` to `WT::S3Signer.for_s3_bucket`, so it's possible to inject a cached `Aws::S3::Client` instance and prevent too many requests to the AWS metadata endpoint

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ An optimized AWS S3 URL signer.
 s3_bucket = Aws::S3::Bucket.new('shiny-bucket-name')
 ttl_seconds = 7 * 24 * 60 * 60
 
-signer = WT::S3Signer.for_s3_bucket(s3_bucket, expires_in: ttl_seconds)
+# we suggest caching the S3 client in the application to reuse the cached credentials
+s3_client = Aws::S3::Client.new
+signer = WT::S3Signer.for_s3_bucket(s3_bucket, client: s3_client, expires_in: ttl_seconds)
 url_str = signer.presigned_get_url(object_key: full_s3_key)
       #=> https://shiny-bucket-name.s3.eu-west-1.amazonaws.com/dir/testobject?X-Amz-Algorithm...
 ```

--- a/lib/wt_s3_signer.rb
+++ b/lib/wt_s3_signer.rb
@@ -26,16 +26,18 @@ module WT
     # region and so forth.
     #
     # @param bucket[Aws::S3::Bucket] the AWS bucket resource object
+    # @param client[Aws::S3::Client] an instance AWS S3 Client. It's recommended
+    # to cache it in the application to avoid having too many HTTP requests to
+    # the AWS instance metadata endpoint
     # @param extra_attributes[Hash] any extra keyword arguments to pass to `S3Signer.new`
     # @return [WT::S3Signer]
-    def self.for_s3_bucket(bucket, **extra_attributes)
+    def self.for_s3_bucket(bucket, client: Aws::S3::Client.new, **extra_attributes)
       kwargs = {}
 
       kwargs[:bucket_endpoint_url] = bucket.url
       kwargs[:bucket_host] = URI.parse(bucket.url).host
       kwargs[:bucket_name] = bucket.name
 
-      client = Aws::S3::Client.new
       resp = client.get_bucket_location(bucket: bucket.name)
       aws_region = resp.data.location_constraint
 

--- a/spec/url_signing_spec.rb
+++ b/spec/url_signing_spec.rb
@@ -44,4 +44,22 @@ describe WT::S3Signer do
     expect{signer.presigned_get_url(object_key: '')}.to raise_error(ArgumentError)
   end
 
+  describe '.for_s3_bucket' do
+    it 'accepts an s3_client instance via dependency injection' do
+      allow(WT::S3Signer).to receive(:create_bucket).and_return(bucket)
+      bucket.object('dir/testobject').put(body: 'is here')
+
+      s3_client = Aws::S3::Client.new
+
+      expect(Aws::S3::Client).not_to receive(:new)
+
+      signer = described_class.for_s3_bucket(
+        bucket, client: s3_client, expires_in: 174
+      )
+
+      presigned_url = signer.presigned_get_url(object_key: 'dir/testobject')
+
+      expect(presigned_url).to include("X-Amz-Expires=174")
+    end
+  end
 end


### PR DESCRIPTION
## Motivation

Every time that we call `WT::S3Signer.for_s3_bucket`, it creates a new instance of `Aws::S3::Client` inside of it.

With that, AWS credentials will not be cached when using `Aws::InstanceProfileCredentials` and it will make 3 HTTP requests to the AWS metadata endpoint every time the application calls `WT::S3Signer.for_s3_bucket`.

## Proposal

This PR changes the method `WT::S3Signer.for_s3_bucket` to accept an S3 client as an argument, so it's possible to cache it in the application.