### PR TITLE
Change .for_s3_bucket to use an internal singleton s3_client by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
+## 1.0.0
+* Remove option `client:` `from WT::S3Signer.for_s3_bucket`
+* Uses a singleton s3_client by default to take advantage of AWS credentials cache
+
 ## 0.3.0
 * Add option `client:` to `WT::S3Signer.for_s3_bucket`, so it's possible to inject a cached `Aws::S3::Client` instance and prevent too many requests to the AWS metadata endpoint

--- a/lib/wt_s3_signer.rb
+++ b/lib/wt_s3_signer.rb
@@ -31,7 +31,7 @@ module WT
     # the AWS instance metadata endpoint
     # @param extra_attributes[Hash] any extra keyword arguments to pass to `S3Signer.new`
     # @return [WT::S3Signer]
-    def self.for_s3_bucket(bucket, client: Aws::S3::Client.new, **extra_attributes)
+    def self.for_s3_bucket(bucket, **extra_attributes)
       kwargs = {}
 
       kwargs[:bucket_endpoint_url] = bucket.url
@@ -169,6 +169,13 @@ module WT
     def create_bucket(bucket_name)
       Aws::S3::Bucket.new(bucket_name)
     end
+
+    # AWS gems have a mechanism to cache credentials internally. So take
+    # advantage of this, it's necessary to use the same client instance.
+    def self.client
+      @client ||= Aws::S3::Client.new
+    end
+    private_class_method :client
 
     def derive_signing_key(key, datestamp, region, service)
       prefixed_key = "AWS4" + key


### PR DESCRIPTION
related to https://github.com/WeTransfer/wt_s3_signer/pull/12

We used a singleton client in our applications for a while and we had no problems with that.

This PR changes the method `.for_s3_bucket` to use a singleton s3_client, created internally, by default.