### PR TITLE
Set instance_profile_credentials_retries to 5 on S3::Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.1
+* Set `instance_profile_credentials_retries` to 5 in the S3::Client instance to prevent "missing credentials" errors
+
 ## 1.0.0
 * Remove option `client:` `from WT::S3Signer.for_s3_bucket`
 * Uses a singleton s3_client by default to take advantage of AWS credentials cache

--- a/lib/wt_s3_signer.rb
+++ b/lib/wt_s3_signer.rb
@@ -173,7 +173,11 @@ module WT
     # AWS gems have a mechanism to cache credentials internally. So take
     # advantage of this, it's necessary to use the same client instance.
     def self.client
-      @client ||= Aws::S3::Client.new
+      @client ||= Aws::S3::Client.new(
+        # The default value is 0. If the metadata service fails to respond, it
+        # will raise missing credentials when used
+        instance_profile_credentials_retries: 5,
+      )
     end
     private_class_method :client
 


### PR DESCRIPTION
We noticed some errors `Aws::Errors::MissingCredentialsError` with the message `unable to sign request without credentials set`.

After researching on the internet, I found [this suggestion](https://github.com/aws/aws-sdk-ruby/issues/1301#issuecomment-261117898) to set `instance_profile_credentials_retries` to 5, which I realized is the same thing we do on Sqewer [here](https://github.com/WeTransfer/sqewer/blob/master/lib/sqewer/connection.rb#L50). So I think it may work!