### PR TITLE
Release S3 singleton client when AWS raises credentials related errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2
+* Release the singleton S3 client when AWS raises access denied to be able to use a new credential next time
+
 ## 1.0.1
 * Set `instance_profile_credentials_retries` to 5 in the S3::Client instance to prevent "missing credentials" errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.0.2
-* Release the singleton S3 client when AWS raises access denied to be able to use a new credential next time
+* Release the singleton S3 client when AWS raises credential error to be able to use a new credential next time
 
 ## 1.0.1
 * Set `instance_profile_credentials_retries` to 5 in the S3::Client instance to prevent "missing credentials" errors

--- a/lib/wt_s3_signer.rb
+++ b/lib/wt_s3_signer.rb
@@ -56,6 +56,14 @@ module WT
       kwargs[:session_token] = credentials.session_token
 
       new(**kwargs, **extra_attributes)
+    rescue Aws::S3::Errors::AccessDenied
+      # We noticed cases where errors related to AWS credentials started to happen suddenly.
+      # We don't know the root cause yet, but what we can do is release the
+      # @client instance because it contains a cache of credentials that in most cases
+      # is no longer valid.
+      @client = nil
+
+      raise
     end
 
     # Creates a new instance of WT::S3Signer
@@ -164,12 +172,6 @@ module WT
       @bucket_endpoint + canonical_uri + "?" + qs_with_signature
     end
 
-    private
-
-    def create_bucket(bucket_name)
-      Aws::S3::Bucket.new(bucket_name)
-    end
-
     # AWS gems have a mechanism to cache credentials internally. So take
     # advantage of this, it's necessary to use the same client instance.
     def self.client
@@ -179,7 +181,12 @@ module WT
         instance_profile_credentials_retries: 5,
       )
     end
-    private_class_method :client
+
+    def self.client=(client)
+      @client = client
+    end
+
+    private
 
     def derive_signing_key(key, datestamp, region, service)
       prefixed_key = "AWS4" + key

--- a/lib/wt_s3_signer.rb
+++ b/lib/wt_s3_signer.rb
@@ -56,7 +56,7 @@ module WT
       kwargs[:session_token] = credentials.session_token
 
       new(**kwargs, **extra_attributes)
-    rescue Aws::S3::Errors::AccessDenied
+    rescue Aws::S3::Errors::AccessDenied, Aws::Errors::MissingCredentialsError
       # We noticed cases where errors related to AWS credentials started to happen suddenly.
       # We don't know the root cause yet, but what we can do is release the
       # @client instance because it contains a cache of credentials that in most cases

--- a/lib/wt_s3_signer/version.rb
+++ b/lib/wt_s3_signer/version.rb
@@ -1,5 +1,5 @@
 module WT
   class S3Signer
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end

--- a/spec/url_signing_spec.rb
+++ b/spec/url_signing_spec.rb
@@ -85,5 +85,28 @@ describe WT::S3Signer do
 
       expect(described_class.client).not_to be(s3_client)
     end
+
+    it 'releases the singleton client when AWS raises a missing credentials error' do
+      s3_client = Aws::S3::Client.new(stub_responses: true)
+      described_class.client = s3_client
+
+      s3_client.stub_responses(:get_object, body: 'is here')
+
+      # just to set @client internally
+      described_class.for_s3_bucket(bucket, expires_in: 174)
+
+      # now, let's simulate an error on AWS
+      s3_client.stub_responses(
+        :get_bucket_location,
+        Aws::Errors::MissingCredentialsError.new(_context = nil, _message = nil)
+      )
+
+      # exercise again
+      expect do
+        described_class.for_s3_bucket(bucket, expires_in: 174)
+      end.to raise_error(Aws::Errors::MissingCredentialsError)
+
+      expect(described_class.client).not_to be(s3_client)
+    end
   end
 end

--- a/wt_s3_signer.gemspec
+++ b/wt_s3_signer.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "rspec-benchmark", "~> 0.6"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "pry-byebug"
 end


### PR DESCRIPTION
We noticed cases where errors related to AWS credentials started to happen suddenly.

We don't know the root cause yet, but what we can do is release the `@client` instance because it contains a cache of credentials that in most cases is no longer valid.

I also added `pry-byebug` to help to debug it.